### PR TITLE
fix: preserve TUN auto-detect key in JSON

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -271,7 +271,7 @@ type RawTun struct {
 	Stack               C.TUNStack `yaml:"stack" json:"stack"`
 	DNSHijack           []string   `yaml:"dns-hijack" json:"dns-hijack"`
 	AutoRoute           bool       `yaml:"auto-route" json:"auto-route"`
-	AutoDetectInterface bool       `yaml:"auto-detect-interface"`
+	AutoDetectInterface bool       `yaml:"auto-detect-interface" json:"auto-detect-interface"`
 
 	MTU        uint32 `yaml:"mtu" json:"mtu,omitempty"`
 	GSO        bool   `yaml:"gso" json:"gso,omitempty"`

--- a/config/raw_tun_test.go
+++ b/config/raw_tun_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRawTunJSONUsesMihomoAutoDetectInterfaceKey(t *testing.T) {
+	data, err := json.Marshal(RawTun{AutoDetectInterface: true})
+	if err != nil {
+		t.Fatalf("marshal RawTun: %v", err)
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("unmarshal RawTun JSON: %v", err)
+	}
+
+	if got := fields["auto-detect-interface"]; got != true {
+		t.Fatalf("auto-detect-interface = %v, want true", got)
+	}
+	if _, found := fields["AutoDetectInterface"]; found {
+		t.Fatal("unexpected Go field name in RawTun JSON")
+	}
+}


### PR DESCRIPTION
## Summary
- serialize RawTun.AutoDetectInterface as auto-detect-interface instead of the Go field name
- add a regression test for the JSON field name used by FlClash config round trips

## Related issue
- https://github.com/chen08209/FlClash/issues/1992

## Verification
- Attempted: go test ./config -run TestRawTunJSONUsesMihomoAutoDetectInterfaceKey -count=1.
- The local Go 1.25.0 installation fails while compiling the Go runtime with duplicate Swiss-map symbols before project packages build. Please rely on CI for the test result.